### PR TITLE
Changed port to an uncommon port

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 	npm install
 	node server.js
 
-Then visit http://localhost:8080/
+Then visit http://localhost:8747/
 
 Bookmarklet Guide
 --------

--- a/server.js
+++ b/server.js
@@ -54,6 +54,6 @@ server.get(/\/?.*/, restify.serveStatic({
 server.post('/agsJSON', agsJSON.toGeoJSON);
 
 // Start the server
-server.listen(process.env.VMC_APP_PORT || 8080, function() {
+server.listen(process.env.VMC_APP_PORT || 8747, function() {
 	console.log('%s listening at %s', server.name, server.url);
 });


### PR DESCRIPTION
The 8080 port is commonly used by many webservers, notably tomcat & jetty. Using this port by default might be problematic for many people. Hence I've changed the default port to 8474, which is not a commonly used port.

IMHO, I feel that this will give a better user experience when you have multiple servers running on your system.
